### PR TITLE
Fix model building configuration

### DIFF
--- a/l3embedding/model.py
+++ b/l3embedding/model.py
@@ -24,7 +24,7 @@ def construct_cnn_L3_orig():
     # CONV BLOCK 1
     n_filter_i_1 = 64
     filt_size_i_1 = (3, 3)
-    pool_size_i_1 = (2,2)
+    pool_size_i_1 = (2, 2)
     y_i = Conv2D(n_filter_i_1, filt_size_i_1, padding='same',
                  activation='relu')(x_i)
     y_i = BatchNormalization()(y_i)
@@ -36,7 +36,7 @@ def construct_cnn_L3_orig():
     # CONV BLOCK 2
     n_filter_i_2 = 128
     filt_size_i_2 = (3, 3)
-    pool_size_i_2 = (2,2)
+    pool_size_i_2 = (2, 2)
     y_i = Conv2D(n_filter_i_2, filt_size_i_2, padding='same',
                  activation='relu')(y_i)
     y_i = BatchNormalization()(y_i)
@@ -48,7 +48,7 @@ def construct_cnn_L3_orig():
     # CONV BLOCK 3
     n_filter_i_3 = 256
     filt_size_i_3 = (3, 3)
-    pool_size_i_3 = (2,2)
+    pool_size_i_3 = (2, 2)
     y_i = Conv2D(n_filter_i_3, filt_size_i_3, padding='same',
                  activation='relu')(y_i)
     y_i = BatchNormalization()(y_i)
@@ -67,7 +67,7 @@ def construct_cnn_L3_orig():
     y_i = Conv2D(n_filter_i_4, filt_size_i_4, padding='same',
                  activation='relu')(y_i)
     y_i = BatchNormalization()(y_i)
-    y_i = MaxPooling2D(pool_size=pool_size_i_4, strides=2, padding='same')(y_i)
+    y_i = MaxPooling2D(pool_size=pool_size_i_4, padding='same')(y_i)
     y_i = Flatten()(y_i)
 
 
@@ -75,7 +75,7 @@ def construct_cnn_L3_orig():
     # Audio subnetwork
     ####
     n_dft = 512
-    n_hop = 16
+    n_hop = 242
     asr = 48000
     audio_window_dur = 1
     # INPUT
@@ -88,54 +88,52 @@ def construct_cnn_L3_orig():
     # CONV BLOCK 1
     n_filter_a_1 = 64
     filt_size_a_1 = (3, 3)
-    pool_size_a_1 = (2,2)
-    y_a= Conv2D(n_filter_a_1, filt_size_a_1, padding='same',
-               activation='relu')(y_a)
-    y_a= BatchNormalization()(y_a)
-    y_a= Conv2D(n_filter_a_1, filt_size_a_1, padding='same',
-                       activation='relu')(y_a)
-    y_a= BatchNormalization()(y_a)
-    y_a= MaxPooling2D(pool_size=pool_size_a_1, strides=2, padding='same')(y_a)
+    pool_size_a_1 = (2, 2)
+    y_a = Conv2D(n_filter_a_1, filt_size_a_1, padding='same',
+                activation='relu')(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = Conv2D(n_filter_a_1, filt_size_a_1, padding='same',
+                activation='relu')(y_a)
+    y_a = BatchNormalization()(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_1, strides=2)(y_a)
 
     # CONV BLOCK 2
     n_filter_a_2 = 128
     filt_size_a_2 = (3, 3)
-    pool_size_a_2 = (2,2)
+    pool_size_a_2 = (2, 2)
     y_a = Conv2D(n_filter_a_2, filt_size_a_2, padding='same',
-                activation='relu')(y_a)
+                 activation='relu')(y_a)
     y_a = BatchNormalization()(y_a)
     y_a = Conv2D(n_filter_a_2, filt_size_a_2, padding='same',
-                activation='relu')(y_a)
+                 activation='relu')(y_a)
     y_a = BatchNormalization()(y_a)
-    y_a = MaxPooling2D(pool_size=pool_size_a_2, strides=2, padding='same')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_2, strides=2)(y_a)
 
     # CONV BLOCK 3
     n_filter_a_3 = 256
     filt_size_a_3 = (3, 3)
-    pool_size_a_3 = (2,2)
+    pool_size_a_3 = (2, 2)
     y_a = Conv2D(n_filter_a_3, filt_size_a_3, padding='same',
-                activation='relu')(y_a)
+                 activation='relu')(y_a)
     y_a = BatchNormalization()(y_a)
     y_a = Conv2D(n_filter_a_3, filt_size_a_3, padding='same',
-                activation='relu')(y_a)
+                 activation='relu')(y_a)
     y_a = BatchNormalization()(y_a)
-    y_a = MaxPooling2D(pool_size=pool_size_a_3, strides=2, padding='same')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_3, strides=2)(y_a)
 
     # CONV BLOCK 4
     n_filter_a_4 = 512
     filt_size_a_4 = (3, 3)
     pool_size_a_4 = (32, 24)
     y_a = Conv2D(n_filter_a_4, filt_size_a_4, padding='same',
-                activation='relu')(y_a)
+                 activation='relu')(y_a)
     y_a = BatchNormalization()(y_a)
     y_a = Conv2D(n_filter_a_4, filt_size_a_4, padding='same',
-                activation='relu')(y_a)
+                 activation='relu')(y_a)
     y_a = BatchNormalization()(y_a)
-    y_a = MaxPooling2D(pool_size=pool_size_a_4, strides=2, padding='same')(y_a)
+    y_a = MaxPooling2D(pool_size=pool_size_a_4)(y_a)
 
     y_a = Flatten()(y_a)
-
-
 
     # Merge the subnetworks
     y = Concatenate()([y_i, y_a])


### PR DESCRIPTION
This PR fixes some model building configurations to match the dimension with what's in the paper.

Also in the paper, they specify the spectrogram window as 0.01 of 48000 Hz, which is 480. However, kapre only takes 2 to the power of the window size, the tradeoff is to use 512 window size with 242 hop size to create exact same dimension as in the paper (257 * 199).

Also, modified a little but data generation to match the dimension of audio input as 1 * 48000. And the label as two numbers [0, 1] or [1, 0] to match output softmax layer.

I found that, if you specify enough memory and core, I don't encounter the video reading problem anymore. Therefore, I am going back to the vread methods.