### PR TITLE
Add multi-gpus support

### DIFF
--- a/l3embedding/train.py
+++ b/l3embedding/train.py
@@ -75,9 +75,9 @@ def sample_one_second(audio_data, sampling_frequency, start, label, augment=Fals
     if label:
         start = max(0, int(start * sampling_frequency) - random.randint(0, sampling_frequency))
     else:
-        try:
+        if len(audio_data) > sampling_frequency:
             start = random.randrange(len(audio_data) - sampling_frequency)
-        except ValueError:
+        else:
             start = 0
 
     audio_data = audio_data[start:start+sampling_frequency]

--- a/l3embedding/train.py
+++ b/l3embedding/train.py
@@ -290,7 +290,7 @@ class LossHistory(keras.callbacks.Callback):
 def train(train_data_dir, validation_data_dir, model_id, output_dir,
           num_epochs=150, epoch_size=512, batch_size=64, validation_size=1024,
           num_streamers=16, learning_rate=1e-4, random_state=20171021,
-          verbose=False, checkpoint_interval=100, augment=False, gpus=1):
+          verbose=False, checkpoint_interval=10, augment=False, gpus=1):
     single_gpu_model, inputs, outputs = construct_cnn_L3_orig()
     m = multi_gpu_model(single_gpu_model, gpus=gpus)
     loss = 'binary_crossentropy'

--- a/l3embedding/train.py
+++ b/l3embedding/train.py
@@ -1,9 +1,9 @@
 import glob
 import json
+import math
 import os
 import pickle
 import random
-import math
 
 import keras
 from keras.optimizers import Adam
@@ -14,8 +14,9 @@ from skvideo.io import vread
 import soundfile as sf
 from tqdm import tqdm
 
-from .model import construct_cnn_L3_orig
 from .image import *
+from .model import construct_cnn_L3_orig
+from .training_utils import multi_gpu_model
 
 
 #TODO: Consider putting the sampling functionality into another file
@@ -284,8 +285,9 @@ class LossHistory(keras.callbacks.Callback):
 def train(train_data_dir, validation_data_dir, model_id, output_dir,
           num_epochs=150, epoch_size=512, batch_size=64, validation_size=1024,
           num_streamers=16, learning_rate=1e-4, random_state=20171021,
-          verbose=False, checkpoint_interval=100, augment=False):
-    m, inputs, outputs = construct_cnn_L3_orig()
+          verbose=False, checkpoint_interval=100, augment=False, gpus=1):
+    single_gpu_model, inputs, outputs = construct_cnn_L3_orig()
+    m = multi_gpu_model(single_gpu_model, gpus=gpus)
     loss = 'binary_crossentropy'
     metrics = ['accuracy']
     #monitor = 'val_loss'

--- a/l3embedding/train.py
+++ b/l3embedding/train.py
@@ -75,7 +75,10 @@ def sample_one_second(audio_data, sampling_frequency, start, label, augment=Fals
     if label:
         start = max(0, int(start * sampling_frequency) - random.randint(0, sampling_frequency))
     else:
-        start = random.randrange(len(audio_data) - sampling_frequency)
+        try:
+            start = random.randrange(len(audio_data) - sampling_frequency)
+        except ValueError:
+            start = 0
 
     audio_data = audio_data[start:start+sampling_frequency]
     if augment:
@@ -209,11 +212,13 @@ def sampler(video_file, audio_files, augment=False):
     audio_data, sampling_frequency = sf.read(audio_file)
 
     while True:
-        sample_video_data, video_start, video_aug_params \
-            = sample_one_frame(video_data, augment=augment)
-        sample_audio_data, audio_start, audio_aug_params \
-            = sample_one_second(audio_data, sampling_frequency, video_start,
-                                label, augment=augment)
+        sample_video_data, video_start, video_aug_params = sample_one_frame(video_data,
+                                                                            augment=augment)
+        sample_audio_data, audio_start, audio_aug_params = sample_one_second(audio_data,
+                                                                             sampling_frequency,
+                                                                             video_start,
+                                                                             label,
+                                                                             augment=augment)
         sample_audio_data = sample_audio_data[:, 0].reshape((1, len(sample_audio_data)))
 
         sample = {

--- a/l3embedding/training_utils.py
+++ b/l3embedding/training_utils.py
@@ -1,0 +1,170 @@
+# Copy of https://github.com/fchollet/keras/blob/master/keras/utils/training_utils.py
+# Move import tensorflow as tf to the top to address the pickle issue
+# https://github.com/fchollet/keras/issues/8123
+
+from keras import backend as K
+from keras.engine.training import Model
+from keras.layers.core import Lambda
+from keras.layers.merge import concatenate
+import tensorflow as tf
+
+
+def _get_available_devices():
+    return [x.name for x in K.get_session().list_devices()]
+
+
+def _normalize_device_name(name):
+    name = '/' + name.lower().split('device:')[1]
+    return name
+
+
+def multi_gpu_model(model, gpus):
+    """Replicates a model on different GPUs.
+
+    Specifically, this function implements single-machine
+    multi-GPU data parallelism. It works in the following way:
+
+    - Divide the model's input(s) into multiple sub-batches.
+    - Apply a model copy on each sub-batch. Every model copy
+        is executed on a dedicated GPU.
+    - Concatenate the results (on CPU) into one big batch.
+
+    E.g. if your `batch_size` is 64 and you use `gpus=2`,
+    then we will divide the input into 2 sub-batches of 32 samples,
+    process each sub-batch on one GPU, then return the full
+    batch of 64 processed samples.
+
+    This induces quasi-linear speedup on up to 8 GPUs.
+
+    This function is only available with the TensorFlow backend
+    for the time being.
+
+    # Arguments
+        model: A Keras model instance. To avoid OOM errors,
+            this model could have been built on CPU, for instance
+            (see usage example below).
+        gpus: Integer >= 2, number of on GPUs on which to create
+            model replicas.
+
+    # Returns
+        A Keras `Model` instance which can be used just like the initial
+        `model` argument, but which distributes its workload on multiple GPUs.
+
+    # Example
+
+    ```python
+        import tensorflow as tf
+        from keras.applications import Xception
+        from keras.utils import multi_gpu_model
+        import numpy as np
+
+        num_samples = 1000
+        height = 224
+        width = 224
+        num_classes = 1000
+
+        # Instantiate the base model (or "template" model).
+        # We recommend doing this with under a CPU device scope,
+        # so that the model's weights are hosted on CPU memory.
+        # Otherwise they may end up hosted on a GPU, which would
+        # complicate weight sharing.
+        with tf.device('/cpu:0'):
+            model = Xception(weights=None,
+                             input_shape=(height, width, 3),
+                             classes=num_classes)
+
+        # Replicates the model on 8 GPUs.
+        # This assumes that your machine has 8 available GPUs.
+        parallel_model = multi_gpu_model(model, gpus=8)
+        parallel_model.compile(loss='categorical_crossentropy',
+                               optimizer='rmsprop')
+
+        # Generate dummy data.
+        x = np.random.random((num_samples, height, width, 3))
+        y = np.random.random((num_samples, num_classes))
+
+        # This `fit` call will be distributed on 8 GPUs.
+        # Since the batch size is 256, each GPU will process 32 samples.
+        parallel_model.fit(x, y, epochs=20, batch_size=256)
+
+        # Save model via the template model (which shares the same weights):
+        model.save('my_model.h5')
+    ```
+
+    # On model saving
+
+    To save the multi-gpu model, use `.save(fname)` or `.save_weights(fname)`
+    with the template model (the argument you passed to `multi_gpu_model),
+    rather than the model returned by `multi_gpu_model`.
+    """
+    if K.backend() != 'tensorflow':
+        raise ValueError('`multi_gpu_model` is only available '
+                         'with the TensorFlow backend.')
+    if gpus <= 1:
+        raise ValueError('For multi-gpu usage to be effective, '
+                         'call `multi_gpu_model` with `gpus >= 2`. '
+                         'Received: `gpus=%d`' % gpus)
+
+    target_devices = ['/cpu:0'] + ['/gpu:%d' % i for i in range(gpus)]
+    available_devices = _get_available_devices()
+    available_devices = [_normalize_device_name(name) for name in available_devices]
+    for device in target_devices:
+        if device not in available_devices:
+            raise ValueError(
+                'To call `multi_gpu_model` with `gpus=%d`, '
+                'we expect the following devices to be available: %s. '
+                'However this machine only has: %s. '
+                'Try reducing `gpus`.' % (gpus,
+                                          target_devices,
+                                          available_devices))
+
+    def get_slice(data, i, parts):
+        shape = tf.shape(data)
+        batch_size = shape[:1]
+        input_shape = shape[1:]
+        step = batch_size // parts
+        if i == gpus - 1:
+            size = batch_size - step * i
+        else:
+            size = step
+        size = tf.concat([size, input_shape], axis=0)
+        stride = tf.concat([step, input_shape * 0], axis=0)
+        start = stride * i
+        return tf.slice(data, start, size)
+
+    all_outputs = []
+    for i in range(len(model.outputs)):
+        all_outputs.append([])
+
+    # Place a copy of the model on each GPU,
+    # each getting a slice of the inputs.
+    for i in range(gpus):
+        with tf.device('/gpu:%d' % i):
+            with tf.name_scope('replica_%d' % i):
+                inputs = []
+                # Retrieve a slice of the input.
+                for x in model.inputs:
+                    input_shape = tuple(x.get_shape().as_list())[1:]
+                    slice_i = Lambda(get_slice,
+                                     output_shape=input_shape,
+                                     arguments={'i': i,
+                                                'parts': gpus})(x)
+                    inputs.append(slice_i)
+
+                # Apply model on slice
+                # (creating a model replica on the target device).
+                outputs = model(inputs)
+                if not isinstance(outputs, list):
+                    outputs = [outputs]
+
+                # Save the outputs for merging back together later.
+                for o in range(len(outputs)):
+                    all_outputs[o].append(outputs[o])
+
+    # Merge outputs on CPU.
+    with tf.device('/cpu:0'):
+        merged = []
+        for outputs in all_outputs:
+            merged.append(concatenate(outputs,
+                                      axis=0))
+        return Model(model.inputs, merged)

--- a/train.py
+++ b/train.py
@@ -76,6 +76,11 @@ def parse_arguments():
                         default=False,
                         help='If True, performs data augmentation on audio and images')
 
+    parser.add_argument('--gpus',
+                        dest='gpus',
+                        default=1,
+                        help='Number of gpus used for data parallelism.')
+
     parser.add_argument('-v',
                         '--verbose',
                         dest='verbose',

--- a/train.py
+++ b/train.py
@@ -78,6 +78,7 @@ def parse_arguments():
 
     parser.add_argument('--gpus',
                         dest='gpus',
+                        type=int,
                         default=1,
                         help='Number of gpus used for data parallelism.')
 


### PR DESCRIPTION
Couple things worth noted when I am trying to make multi-gpus work.

You can try to use this snippet to verify if your program recognize gpus.
```
from tensorflow.python.client import device_lib
device_lib.list_local_devices()
```

Make sure you install the gpu version of tensorflow.
```
pip install --upgrade tensorflow-gpu
```

In your script you will need to add these two modules.
```
module load cuda/8.0.44
module load cudnn/8.0v6.0
```

I haven't figured out how to specify gpu memories. When I use batch_size=64, it always complaints about gpu memory. Currently I am using 32 or 16 if 32 does not work.

The reason that a copy of training_utils.py is included is that the `import tensorflow as tf` line cause the model unserializable.