### PR TITLE
Include all video files for samples

### DIFF
--- a/l3embedding/train.py
+++ b/l3embedding/train.py
@@ -252,7 +252,7 @@ def data_generator(data_dir, k=32, batch_size=64, random_state=20171021, augment
 
     audio_files, video_files = get_file_list(data_dir)
     seeds = []
-    for video_file in tqdm(random.sample(video_files, k)):
+    for video_file in tqdm(video_files):
         seeds.append(pescador.Streamer(sampler, video_file, audio_files, augment=augment))
 
     mux = pescador.Mux(seeds, k)


### PR DESCRIPTION
I think we are doing it wrong, we should include all video files and let pescador sample in mux for us.

I did some auditing and found out that in our original setting, for lots of batches we only sample from those k files we set as streamer. I think it is wrong.